### PR TITLE
Update build information

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,10 +53,22 @@ You can also add ProtocolLib as a Maven dependency:
   <dependency>
     <groupId>com.comphenix.protocol</groupId>
     <artifactId>ProtocolLib</artifactId>
-    <version>3.6.5</version>
+    <version>4.3.0</version>
   </dependency>
 </dependencies>
 ````
+
+Or use the maven dependency with gradle:
+
+```gradle
+repositories {
+    maven { url "http://repo.dmulloy2.net/content/groups/public/" }
+}
+
+dependencies {
+    compileOnly group: "com.comphenix.protocol", name: "ProtocolLib", version: "4.3.0";
+}
+```
 
 Then get a reference to ProtocolManager in onLoad() or onEnable() and you're good to go.
 


### PR DESCRIPTION
This adds the following:
- Switch to 4.3.0 version
- Include Gradle information

The current version listed isn't available in the repo anymore, and it would be nice to add some information about Gradle. 